### PR TITLE
feat: controlflow verbose

### DIFF
--- a/src/components/Editor/Output/ControlflowPanel.vue
+++ b/src/components/Editor/Output/ControlflowPanel.vue
@@ -3,12 +3,12 @@ import { instance } from '@viz-js/viz'
 import { debouncedWatch } from '@vueuse/core'
 import Checkbox from 'src/components/ui/Checkbox.vue'
 import { useOxc } from 'src/composables/oxc'
-import { ref, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, watch } from 'vue'
 import OutputPreview from './OutputPreview.vue'
 
 const viz = await instance()
 
-const { oxc } = await useOxc()
+const { oxc, options } = await useOxc()
 const panelEl = useTemplateRef<HTMLDivElement>('panel')
 
 debouncedWatch(
@@ -22,13 +22,22 @@ debouncedWatch(
 )
 
 const raw = ref(false)
+const verbose = ref(false)
+
+watch(
+  () => verbose.value,
+  (val) => {
+    options.value.controlFlow.verbose = val
+  },
+)
 </script>
 
 <template>
   <div class="w-full flex flex-col overflow-auto">
     <Checkbox id="raw" v-model="raw" title="Raw" class="p-2" />
+    <Checkbox id="verbose" v-model="verbose" title="Verbose" class="p-2" />
 
-    <OutputPreview v-show="raw" :code="oxc.controlFlowGraph" lang="tsx" />
+    <OutputPreview v-show="raw" :code="oxc.controlFlowGraph" lang="text" />
     <!-- eslint-disable-next-line vue/no-unused-refs -->
     <div v-show="!raw" ref="panel" />
   </div>

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -37,6 +37,9 @@ export const useOxc = createGlobalState(async () => {
     transformer: {},
     codegen: {},
     minifier: {},
+    controlFlow: {
+      verbose: true,
+    },
   })
   const oxc = await oxcPromise
   const state = shallowRef(oxc)

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -38,7 +38,7 @@ export const useOxc = createGlobalState(async () => {
     codegen: {},
     minifier: {},
     controlFlow: {
-      verbose: true,
+      verbose: false,
     },
   })
   const oxc = await oxcPromise

--- a/src/utils/shiki.ts
+++ b/src/utils/shiki.ts
@@ -12,7 +12,7 @@ export const highlighterPromise = createHighlighterCore({
   loadWasm: getWasm,
 })
 
-export type ShikiLang = 'json' | 'tsx' | 'dot'
+export type ShikiLang = 'json' | 'tsx' | 'text'
 
 export function highlight(
   highlighter: HighlighterCore,

--- a/src/utils/shiki.ts
+++ b/src/utils/shiki.ts
@@ -12,7 +12,7 @@ export const highlighterPromise = createHighlighterCore({
   loadWasm: getWasm,
 })
 
-export type ShikiLang = 'json' | 'tsx'
+export type ShikiLang = 'json' | 'tsx' | 'dot'
 
 export function highlight(
   highlighter: HighlighterCore,


### PR DESCRIPTION
require: https://github.com/oxc-project/oxc/pull/5879
1. Adding a new option to control displaying `implicit error` edge.
**verbose**
![image](https://github.com/user-attachments/assets/cef43d5f-25d0-4408-ad4a-34bc633f2821)
**disable verbose**
![image](https://github.com/user-attachments/assets/02954103-689c-422c-8ada-5805a39335b7)
