### PR TITLE
fix: rename `astNodeId` to `nodeId` in symbol table display

### DIFF
--- a/src/components/Editor/Output/SymbolPanel.vue
+++ b/src/components/Editor/Output/SymbolPanel.vue
@@ -8,7 +8,7 @@ const symbols = computed(() => {
   const { symbols: symbolTable } = oxc.value
   if (!symbolTable) return []
 
-  return symbolTable.declarations.map((astNodeId, symbolId) => {
+  return symbolTable.declarations.map((nodeId, symbolId) => {
     const name = symbolTable.names[symbolId]
     const span = symbolTable.spans[symbolId]
     const flags = symbolTable.flags[symbolId]
@@ -21,7 +21,7 @@ const symbols = computed(() => {
     return {
       name,
       span,
-      astNodeId,
+      nodeId,
       scopeId,
       flags,
       references,


### PR DESCRIPTION
We renamed `ast_node_id` to `node_id`. Reflect this naming change in Playground's symbol table display.