### PR TITLE
fix: fix source map visualizer link for unicode

### DIFF
--- a/src/components/output/CodegenPanel.vue
+++ b/src/components/output/CodegenPanel.vue
@@ -9,6 +9,8 @@ const sourcemapLink = computed(() => {
   let code = oxc.value.codegenText
   let map = oxc.value.codegenSourcemapText
   if (code && map) {
+    // encoding url hash for
+    // https://github.com/evanw/source-map-visualization/blob/f3e9dfec20e7bfd9625d03dd0d427affa74a9c43/code.js#L2004-L2023
     const utf16ToUTF8 = (x: string) => unescape(encodeURIComponent(x))
     code = utf16ToUTF8(code)
     map = utf16ToUTF8(map)

--- a/src/components/output/CodegenPanel.vue
+++ b/src/components/output/CodegenPanel.vue
@@ -6,9 +6,12 @@ import OutputPreview from './OutputPreview.vue'
 const { oxc } = await useOxc()
 
 const sourcemapLink = computed(() => {
-  const code = oxc.value.codegenText
-  const map = oxc.value.codegenSourcemapText
+  let code = oxc.value.codegenText
+  let map = oxc.value.codegenSourcemapText
   if (code && map) {
+    const utf16ToUTF8 = (x: string) => unescape(encodeURIComponent(x))
+    code = utf16ToUTF8(code)
+    map = utf16ToUTF8(map)
     const hash = btoa(`${code.length}\0${code}${map.length}\0${map}`)
     return `https://evanw.github.io/source-map-visualization/#${hash}`
   }


### PR DESCRIPTION
Fixes https://github.com/oxc-project/playground/pull/63#issuecomment-2692292430

`btoa` doesn't support unicode directly, so I added `utf16ToUTF8` to get proper base64. This encoding is to match the decoding process in https://github.com/evanw/source-map-visualization/blob/f3e9dfec20e7bfd9625d03dd0d427affa74a9c43/code.js#L2004-L2023

Here is an example of a new link:
https://evanw.github.io/source-map-visualization/#MzcAY29uc29sZS5sb2coIvCfmKLwn5iiIiwgIvCfmITwn5iEIik7CjE0NgB7InZlcnNpb24iOjMsIm5hbWVzIjpbXSwic291cmNlcyI6WyJ0ZXN0LnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJjb25zb2xlLmxvZyhcIvCfmKLwn5iiXCIsIFwi8J+YhPCfmIRcIikiXSwibWFwcGluZ3MiOiJBQUFBLFFBQVEsSUFBSSxRQUFRLE9BQU8ifQ==

![image](https://github.com/user-attachments/assets/4c2d5cc3-c822-4dd4-afdb-80986df749e8)
