### PR TITLE
chore: remove oxc-playground from optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,8 +17,6 @@ export default defineConfig({
     esbuildOptions: {
       target: 'esnext',
     },
-    // TODO: optimized linked dep needs restart with `--force` to pick up changes
-    include: ['oxc-playground'],
   },
   server: {
     // These two cross origin headers are used to fix the following error:


### PR DESCRIPTION
I added this since I thought we might hit https://github.com/vitejs/vite/issues/19639 during dev, but I think this is not the case when we use `link:../oxc/napi/playground`. 
Removing this allows directly editing `napi/playground/playground.wasi-browser.js` and auto reloading on this playground. Previously it needed manual server restart with `--force`.