### PR TITLE
chore: enhance code robustness

### DIFF
--- a/src/components/input/InputEditor.vue
+++ b/src/components/input/InputEditor.vue
@@ -22,8 +22,8 @@ const markers = computed((): monaco.editor.IMarkerData[] => {
 
   const diagnostics = oxc.value.getDiagnostics()
   return diagnostics.map((d) => {
-    const startPos = getPositionAt.value(d.labels[0].start ?? 0)
-    const endPos = getPositionAt.value(d.labels[0].end ?? 0)
+    const startPos = getPositionAt.value(d.labels[0]?.start ?? 0)
+    const endPos = getPositionAt.value(d.labels[0]?.end ?? 0)
     return {
       severity:
         d.severity === 'Warning'

--- a/src/components/output/EsTreePanel.vue
+++ b/src/components/output/EsTreePanel.vue
@@ -11,7 +11,13 @@ const { oxc } = await useOxc()
 const value = computed(() => {
   const comments = oxc.value.getComments()
   const errors = oxc.value.getDiagnostics()
-  const program = oxc.value.ast
+  let program = {}
+  try {
+    // Here may throw errors, 'cause access `ast` will automatically invoke `JSON.parse()`.
+    program = oxc.value.ast
+  } catch (error) {
+    console.error(error)
+  }
   return { program, comments, errors }
 })
 

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -89,11 +89,12 @@ export const useOxc = createGlobalState(async () => {
   editorValue.value = urlState?.c || PLAYGROUND_DEMO_CODE
 
   watchEffect(() => {
+    const serialized = JSON.stringify({
+      c: editorValue.value === PLAYGROUND_DEMO_CODE ? '' : editorValue.value,
+      o: options.value,
+    })
+
     try {
-      const serialized = JSON.stringify({
-        c: editorValue.value === PLAYGROUND_DEMO_CODE ? '' : editorValue.value,
-        o: options.value,
-      })
       history.replaceState({}, '', `#${utoa(serialized)}`)
     } catch (error) {
       console.error(error)

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -73,19 +73,31 @@ export const useOxc = createGlobalState(async () => {
   }
   watch([options, editorValue], run, { deep: true })
 
-  const rawUrlState = atou(location.hash!.slice(1))
-  const urlState = rawUrlState && JSON.parse(rawUrlState)
-  if (rawUrlState) {
+  let rawUrlState = ''
+  let urlState = null
+  try {
+    rawUrlState = atou(location.hash!.slice(1))
+    urlState = rawUrlState && JSON.parse(rawUrlState)
+  } catch (error) {
+    console.error(error)
+  }
+
+  if (rawUrlState && urlState?.o) {
     options.value = urlState.o
   }
+
   editorValue.value = urlState?.c || PLAYGROUND_DEMO_CODE
 
   watchEffect(() => {
-    const serialized = JSON.stringify({
-      c: editorValue.value === PLAYGROUND_DEMO_CODE ? '' : editorValue.value,
-      o: options.value,
-    })
-    history.replaceState({}, '', `#${utoa(serialized)}`)
+    try {
+      const serialized = JSON.stringify({
+        c: editorValue.value === PLAYGROUND_DEMO_CODE ? '' : editorValue.value,
+        o: options.value,
+      })
+      history.replaceState({}, '', `#${utoa(serialized)}`)
+    } catch (error) {
+      console.error(error)
+    }
   })
 
   const monacoLanguage = computed(() => {

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -73,7 +73,7 @@ export const useOxc = createGlobalState(async () => {
   }
   watch([options, editorValue], run, { deep: true })
 
-  let rawUrlState = ''
+  let rawUrlState: string | undefined
   let urlState: any
   try {
     rawUrlState = atou(location.hash!.slice(1))

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -82,7 +82,7 @@ export const useOxc = createGlobalState(async () => {
     console.error(error)
   }
 
-  if (rawUrlState && urlState?.o) {
+  if (urlState?.o) {
     options.value = urlState.o
   }
 

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -74,7 +74,7 @@ export const useOxc = createGlobalState(async () => {
   watch([options, editorValue], run, { deep: true })
 
   let rawUrlState = ''
-  let urlState = null
+  let urlState: any
   try {
     rawUrlState = atou(location.hash!.slice(1))
     urlState = rawUrlState && JSON.parse(rawUrlState)


### PR DESCRIPTION
Invoking `atob`, `btoa`, `JSON.parse` or `JSON.stringify` may throw errors.

Refresh the page, after the errors threw, the page will hang on and always show the `loading wasm` skeleton.

If the page hash is invalid.
E.g., 
what if users modify the hash manually. 🤣 Edge case. 硬杠


And for enhancing the robustness of acessing `oxc.ast` property, I'm fixing some issue of the Oxc: https://github.com/oxc-project/oxc/pull/9920, previously I reset the `ast` as `()`, and the `ast_json` as empty string. Then accessing the `oxc.ast`  from the playground will throw errors 'cause it try to parse the `ast_json` - empty string.