### PR TITLE
fix: use original JSON for raw JSON AST display

### DIFF
--- a/src/components/output/EsTreePanel.vue
+++ b/src/components/output/EsTreePanel.vue
@@ -22,7 +22,11 @@ const value = computed(() => {
 })
 
 const code = computed(() => {
-  return JSON.stringify(value.value, undefined, 2)
+  // Trim off first and last lines which contain `{"node":` and `,"fixes":[]}`
+  let json = oxc.value.astJson
+  json = json.slice(json.indexOf('\n') + 1)
+  json = json.slice(0, json.lastIndexOf('\n'))
+  return json
 })
 </script>
 


### PR DESCRIPTION
Currently display of AST as raw JSON crashes if the AST contains a `BigInt`. This is because currently the display uses `JSON.stringify` on the AST Object, and `JSON.stringify` throws if it encounters a `BigInt`.

Instead, use the original JSON produced by Oxc, and avoid stringifying.

Depends on https://github.com/oxc-project/oxc/pull/10869. That needs to be merged first.
