### PR TITLE
feat: Render `RegExp` and `BigInt` nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 Assuming the oxc repository is in `../oxc`:
 
-- in a different terminal and in the `oxc` repository: `just watch-wasm`
+- in a different terminal and in the `oxc` repository: `just watch-playground`
 - in this repo: `pnpm run dev`

--- a/src/components/ast/Value.vue
+++ b/src/components/ast/Value.vue
@@ -10,17 +10,21 @@ const emit = defineEmits<{
   'update:hover': [value: boolean]
 }>()
 
+const isArrayOrObject = computed(() => {
+  if (props.data === null) return false
+  if (Array.isArray(props.data)) return true
+  if (Object.prototype.toString.call(props.data) === '[object Object]')
+    return true
+  return false
+})
 const hasChildren = computed(
-  () =>
-    typeof props.data === 'object' &&
-    props.data != null &&
-    Object.keys(props.data).length > 0,
+  () => isArrayOrObject.value && Object.keys(props.data).length > 0,
 )
 
 const value = computed<string | undefined>(() => {
-  if (typeof props.data === 'object' && props.data !== null) return
-  if (typeof props.data === 'bigint') return String(props.data)
-  return props.data == null ? String(props.data) : JSON.stringify(props.data)
+  if (typeof props.data === 'bigint') return `${String(props.data)}n`
+  if (props.data instanceof RegExp) return props.data.toString()
+  return JSON.stringify(props.data)
 })
 const valueColor = useHighlightColor(value)
 
@@ -32,7 +36,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <template v-if="typeof data === 'object' && data != null">
+  <template v-if="isArrayOrObject">
     <AstBrackets :data>
       <div v-if="hasChildren" ml6>
         <template v-for="(item, key) of data" :key="key">


### PR DESCRIPTION
Fixes #102 


|before|after|
|------|-----|
|![image](https://github.com/user-attachments/assets/54152f4c-eec0-4dff-a54a-ac62c6124420)|![image](https://github.com/user-attachments/assets/2abe4e83-a689-46ef-96c6-6c87d64764c0)|

NOTE: `raw` view is not supported, it shows pure `JSON.stringify()`ed result.