### PR TITLE
refactor: Use more appropriate label for `run.syntax` option

### DIFF
--- a/src/components/sidebar/Parse.vue
+++ b/src/components/sidebar/Parse.vue
@@ -84,8 +84,6 @@ function toggleDts(checked: boolean) {
       @update:model-value="toggleDts"
     />
 
-    <Checkbox v-model="options.run.syntax" label="Check Syntax Errors" />
-
     <Checkbox
       v-model="options.parser.allowReturnOutsideFunction"
       label="allowReturnOutsideFunction"
@@ -99,5 +97,7 @@ function toggleDts(checked: boolean) {
       label="preserveParens"
       font-mono
     />
+
+    <Checkbox v-model="options.run.syntax" label="Show Semantic Errors" />
   </div>
 </template>


### PR DESCRIPTION
Follow up https://github.com/oxc-project/oxc/pull/11065

In addition, updated the display position slightly in terms of this is NOT affecting the output AST.