### PR TITLE
fix: Restore empty code properly

### DIFF
--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -86,7 +86,7 @@ export const useOxc = createGlobalState(async () => {
     options.value = urlState.o
   }
 
-  editorValue.value = urlState?.c || PLAYGROUND_DEMO_CODE
+  editorValue.value = urlState?.c ?? PLAYGROUND_DEMO_CODE
 
   watchEffect(() => {
     const serialized = JSON.stringify({


### PR DESCRIPTION
Fixes #117 

The empty string is falsy in JS, so the placeholder was seemed to be loaded.