### PR TITLE
feat: add semantic errors checkbox to parser options

### DIFF
--- a/src/components/sidebar/Parser.vue
+++ b/src/components/sidebar/Parser.vue
@@ -27,6 +27,12 @@ function handleShowOptions() {
 
     <div v-if="showOptions" flex flex-col gap-2>
       <Checkbox
+        v-model="options.parser.semanticErrors"
+        label="semanticErrors"
+        font-mono
+        label-class="text-xs"
+      />
+      <Checkbox
         v-model="options.parser.preserveParens"
         default-checked
         label="preserveParens"

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -40,6 +40,7 @@ export const useOxc = createGlobalState(async () => {
       allowReturnOutsideFunction: true,
       preserveParens: true,
       allowV8Intrinsics: true,
+      semanticErrors: true,
     },
     linter: {},
     transformer: {


### PR DESCRIPTION
closes #154

## Summary
- Added `semanticErrors` checkbox to the Parser sidebar component
- Positioned above the existing `preserveParens` checkbox in the options section
- Allows users to toggle semantic error checking in the Oxc playground

## Test plan
- [ ] Open the playground and navigate to the Parser section
- [ ] Click on "Options" to expand the parser options
- [ ] Verify the "semanticErrors" checkbox appears above "preserveParens"
- [ ] Test that the checkbox state binds correctly to `options.parser.semanticErrors`

🤖 Generated with [Claude Code](https://claude.ai/code)