### PR TITLE
feat: enable CFG option when controlflow graph tab is active

### DIFF
--- a/src/components/output/OutputPanel.vue
+++ b/src/components/output/OutputPanel.vue
@@ -14,13 +14,14 @@ import SymbolPanel from './SymbolPanel.vue'
 
 const { options } = await useOxc()
 
-function activateFormatter() {
+function updateRunOptions() {
   options.value.run.formatter = activeTab.value === 'formatter'
+  options.value.run.cfg = activeTab.value === 'cfg'
 }
 
-watch([activeTab], activateFormatter)
+watch([activeTab], updateRunOptions)
 
-onMounted(activateFormatter)
+onMounted(updateRunOptions)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
This change enables the `options.value.run.cfg` option when the Controlflow Graph tab is selected in the OutputPanel component. The implementation follows the same pattern as the existing formatter tab behavior, where the corresponding run option is activated based on the active tab.

## Changes
- Modified `src/components/output/OutputPanel.vue` to include CFG option handling
- Renamed `activateFormatter()` function to `updateRunOptions()` to better reflect its expanded purpose
- Added logic to enable `options.value.run.cfg` when the CFG tab is active

## Test plan
- [ ] Verify that switching to the Controlflow Graph tab enables the CFG option
- [ ] Confirm that the formatter tab still works as expected
- [ ] Test that other tabs don't interfere with the CFG option state

🤖 Generated with [Claude Code](https://claude.ai/code)