### PR TITLE
Fix git-commit file to not have short ref.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - run: rustup target add wasm32-wasip1-threads
 
       - run: just build-playground
-      - run: git rev-parse --short HEAD > napi/playground/git-commit
+      - run: git rev-parse HEAD > napi/playground/git-commit
 
       - run: cd .. && mv playground oxc && mkdir playground
 


### PR DESCRIPTION
This is used by the Logo.vue file/`vite.config.ts` to link to the current GitHub commit in the sidebar, which currently doesn't work because it's only the short commit SHA.

Properly fixes #121.