### PR TITLE
fix: prevent code highlight for objects or array

### DIFF
--- a/src/utils/shiki.ts
+++ b/src/utils/shiki.ts
@@ -98,11 +98,6 @@ function escapeHtml(text: string): string {
 
 const highlightToken = useMemoize(async (code: string, theme: string) => {
   try {
-    if (code.length > 100) {
-      console.trace()
-      return { tokens: [[{ color: '#666666' }]] }
-    }
-
     const highlighter = await createHighlighter()
     return highlighter.codeToTokens(code, {
       lang: 'typescript',
@@ -131,8 +126,6 @@ export function useHighlightColor(
       return
     }
 
-    const timer_id = `STAGE_1: ${Math.random().toString(36)} + ${code}`
-    console.time(timer_id)
     try {
       const theme = `vitesse-${dark.value ? 'dark' : 'light'}`
       const result = await highlightToken(code, theme)
@@ -142,7 +135,6 @@ export function useHighlightColor(
     } catch {
       color.value = '#666666' // Fallback color
     }
-    console.timeEnd(timer_id)
   })
 
   return computed(() => color.value)


### PR DESCRIPTION
I noticed the `useHighlightColor` function takes quite long to calc the color, and it blocked the rendering of other components, it make the webpage laggy.

And I trace the code the function received, and found shiki need to parse some full ast node, it is exactly not needed, so this PR fixed it. And the page won't lag anymore.

<img width="884" height="704" alt="image" src="https://github.com/user-attachments/assets/76f38748-e915-4707-9d34-8ef6071935fd" />
