### PR TITLE
fix: allow to run `useHighlightColor` to load shiki

### DIFF
--- a/src/utils/shiki.ts
+++ b/src/utils/shiki.ts
@@ -121,11 +121,6 @@ export function useHighlightColor(
       return
     }
 
-    if (!isLoaded.value && !isLoading.value) {
-      color.value = '#666666' // Default color when not loaded
-      return
-    }
-
     try {
       const theme = `vitesse-${dark.value ? 'dark' : 'light'}`
       const result = await highlightToken(code, theme)


### PR DESCRIPTION
The ast highlighting is not worked after we refresh the page

No shiki will be load if we don't call `highlight` function which will call the `createHighlighter` function and load shiki. 

The `highlightToken` fn also will call `createHighlighter` but the following code prevent it

https://github.com/oxc-project/playground/blob/7fe3b0d97e1254de194ba156028698a47d39f38d/src/utils/shiki.ts#L124-L131

This PR remove the loading status check, to allow `useHighlightColor` to load shiki for highlight

<img width="449" height="676" alt="Screenshot 2025-12-02 at 20 44 05" src="https://github.com/user-attachments/assets/d836f8af-9ee4-4f17-97d5-d2c0d8764cf0" />
