### PR TITLE
fix: process highlight after ui rendering completes

### DIFF
--- a/src/utils/shiki.ts
+++ b/src/utils/shiki.ts
@@ -128,6 +128,8 @@ export function useHighlightColor(
 
     try {
       const theme = `vitesse-${dark.value ? 'dark' : 'light'}`
+      // process the highlight after main rendering completes to prevent laggy
+      await new Promise((res) => requestIdleCallback(res, { timeout: 500 }))
       const result = await highlightToken(code, theme)
       const token = result.tokens[0]
       const idx = code.startsWith('"') && token.length > 1 ? 1 : 0


### PR DESCRIPTION
Since we call `useHighlightColor` function as soon as the components mount (switch to EsTree tab), shiki calls during the component rendering blocked the event loop, it causes the page become unresponsive. 

Now this PR use `requestIdleCallback` function to put off shiki calls to idle time, allowing the page to render first to ensure the ui remain responsive.


<img width="339" height="307" alt="Screenshot 2025-12-02 at 21 23 30" src="https://github.com/user-attachments/assets/c2963cc1-2d36-4a8d-82eb-2cd0ddeb0243" />

https://github.com/user-attachments/assets/b41feccf-626d-46d2-a66d-7dab70fbce0f

