### PR TITLE
style: apply color-scheme attribute in .dark

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,3 +1,7 @@
 .ast-highlight {
   --at-apply: 'bg-blue-400/30 dark:bg-blue-400/20';
 }
+
+.dark {
+  color-scheme: dark;
+}


### PR DESCRIPTION
add `color-scheme: dark` in `.dark` selector to provide better dark mode support to native browser components (e.g. scroll bar)

<img width="456" height="309" alt="Screenshot 2025-12-03 at 20 40 25" src="https://github.com/user-attachments/assets/2be8f643-76bc-4f76-b74a-9919045b10fc" />
<img width="360" height="296" alt="Screenshot 2025-12-03 at 20 42 03" src="https://github.com/user-attachments/assets/6551b485-ed2e-4888-be3b-1839b271805d" />
