### PR TITLE
fix: stringify linter config in options before running oxc

### DIFF
--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -92,7 +92,11 @@ export const useOxc = createGlobalState(async () => {
       return originalError.apply(this, msgs);
     };
     try {
-      oxc.run(editorValue.value, toRaw(options.value));
+      const rawOptions = toRaw(options.value);
+      if (typeof rawOptions?.linter?.config === "object") {
+        rawOptions.linter.config = JSON.stringify(rawOptions.linter.config);
+      }
+      oxc.run(editorValue.value, rawOptions);
       // Reset error if successful
       error.value = undefined;
     } catch (error_) {


### PR DESCRIPTION
this allows putting in options in JSON object form rather than as a stringified string

Before you'd get this error.

![Screenshot 2025-12-19 at 21.34.54.png](https://app.graphite.com/user-attachments/assets/3bc106fe-2507-4065-93f1-9f94cd68c038.png)

Now it's converted to a string before passing to rust