### PR TITLE
fix: watch oxc diagnostics changes rather than computing

### DIFF
--- a/src/components/input/InputEditor.vue
+++ b/src/components/input/InputEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import * as monaco from 'monaco-editor'
-import { computed, useTemplateRef, ref, watchEffect } from 'vue';
+import { computed, ref, useTemplateRef, watchEffect } from 'vue';
 import { useOxc } from '~/composables/oxc'
 import { editorValue } from '~/composables/state'
 import MonacoEditor from '../MonacoEditor.vue'
@@ -17,10 +17,9 @@ const monacoRef = useTemplateRef('monacoRef')
 const getPositionAt = computed(() => monacoRef.value?.getPositionAt)
 const markers = ref<monaco.editor.IMarkerData[]>([]);
 
-  
 watchEffect(() => {
   const getPos = getPositionAt.value;
-  if (!getPos) return []
+  if (!getPos) return
 
   const diagnostics = oxc.value.getDiagnostics()
   markers.value = diagnostics.map((d) => {


### PR DESCRIPTION
I noticed sometimes the editor's diagnostics is not synced with the output below, some ghosty warns / errors don't disappear after changing the code.

And even some real diagnostics are not shown in editor

<img width="477" height="815" alt="Screenshot 2025-12-28 at 20 10 51" src="https://github.com/user-attachments/assets/4d848454-48ef-48ed-920e-7a9c9ed6a121" />

After some researching, I realized the cause is that in some special case, `InputEditor` component will in a strange state.

And while in this state, both dom in `<template>` and `markers`'s value won't be re-rendered or updated while `oxc.getDiagnostics()` getting changed. Only `watch` function can react the change in this strange state.

https://github.com/oxc-project/playground/blob/2f6f11962ccecf2d73f076bfcd8c3c9f61b01bc5/src/components/input/InputEditor.vue#L20-L39

I also tested in `IoContainer` component which doesn't have similar questions. This looks very strange and complexed, and I think it is related to Vue's reactivity system.

Currently, using `watchEffect` seems like a good solution. After testing, the code in this pull request no longer causes the playground to show the behavior in the above image.
