### PR TITLE
chore: deprecate `templateRef`, use `useTemplateRef` instead

### DIFF
--- a/src/components/input/InputEditor.vue
+++ b/src/components/input/InputEditor.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { templateRef } from '@vueuse/core'
 import * as monaco from 'monaco-editor'
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useOxc } from '~/composables/oxc'
 import { editorValue } from '~/composables/state'
 import MonacoEditor from '../MonacoEditor.vue'
@@ -14,16 +13,17 @@ defineProps<{
 
 const { oxc } = await useOxc()
 
-const monacoRef = templateRef<InstanceType<typeof MonacoEditor>>('monacoRef')
+const monacoRef = useTemplateRef('monacoRef')
 const getPositionAt = computed(() => monacoRef.value?.getPositionAt)
 
 const markers = computed((): monaco.editor.IMarkerData[] => {
-  if (!getPositionAt.value) return []
+  const getPos = getPositionAt.value;
+  if (!getPos) return []
 
   const diagnostics = oxc.value.getDiagnostics()
   return diagnostics.map((d) => {
-    const startPos = getPositionAt.value(d.labels[0]?.start ?? 0)
-    const endPos = getPositionAt.value(d.labels[0]?.end ?? 0)
+    const startPos = getPos(d.labels[0]?.start ?? 0)
+    const endPos = getPos(d.labels[0]?.end ?? 0)
     return {
       severity:
         d.severity === 'Warning'


### PR DESCRIPTION
Since [VueUse's `templateRef` hook is deprecated](https://vueuse.org/core/templateRef/#templateref), we should use Vue's native `useTemplateRef` instead

