### PR TITLE
fix: favicon mime type

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="The JavaScript Oxidation Compiler" />
     <title>Oxc - The JavaScript Oxidation Compiler</title>
-    <link rel="icon" type="image/x-icon" href="https://oxc.rs/logo-without-border.svg" />
+    <link rel="icon" type="image/svg+xml" href="https://oxc.rs/logo-without-border.svg" />
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
The favicon wasn't working probably because of incorrect mime type.