### PR TITLE
feat(formatter): replace tabs with checkboxes for Output/IR selection

### DIFF
--- a/src/components/MonacoEditor.vue
+++ b/src/components/MonacoEditor.vue
@@ -23,11 +23,11 @@ let instance: monaco.editor.IStandaloneCodeEditor | undefined;
 const model = shallowRef<monaco.editor.ITextModel>(initModel());
 
 watchEffect((onCleanup) => {
-  const { dispose } = model.value.onDidChangeContent(() => {
+  const dispose = model.value.onDidChangeContent(() => {
     const value = model.value.getValue();
     emit("update:modelValue", value);
   });
-  onCleanup(() => dispose());
+  onCleanup(() => dispose);
 });
 
 function initModel() {


### PR DESCRIPTION
## Summary
- Replace Tab component with checkboxes, allowing both Output and IR to be displayed simultaneously
- Add resizable Splitter panel when both are selected, enabling side-by-side comparison
- Fix Monaco editor height issue (`h-300px` UnoCSS syntax → inline style for Tailwind CSS 4 compatibility)
- Update colors to use design system tokens (`bg-muted`, `text-muted-foreground`, `bg-background`, etc.)
- Simplify template structure for cleaner UI

## Test plan
- [ ] Check "Output" checkbox only → shows formatted output
- [ ] Check "IR" checkbox only → shows IR output
- [ ] Check both checkboxes → shows side-by-side with draggable resizer
- [ ] Uncheck both → shows placeholder message
- [ ] Verify "Configure Options" Monaco editor displays at 300px height
- [ ] Verify styling is consistent with rest of the site (light/dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)