### PR TITLE
fix(css): use class-based dark mode selector for Tailwind v4

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @plugin "tailwindcss-animate";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* shadcn/ui color system */
   --color-background: hsl(var(--background));


### PR DESCRIPTION
## Summary
- Fixes dark mode theme toggle not working correctly when manually switching to the opposite of system preference
- Tailwind CSS v4 defaults to `@media (prefers-color-scheme: dark)` for `dark:` variants, but VueUse's `useDark()` uses `.dark` class on `<html>`
- Added `@custom-variant dark` directive to use class-based selector instead

## Test plan
- [x] Toggle dark mode when system is in light mode - should show dark theme
- [x] Toggle light mode when system is in dark mode - should show light theme
- [x] All UI elements (sidebar, inputs, editor) should follow the toggle correctly

## Screenshot
<img width="2560" height="1319" alt="image" src="https://github.com/user-attachments/assets/7bdc763e-a516-4560-9cd9-3b39b737a183" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)