### PR TITLE
fix: adjust cfg panel box height

### DIFF
--- a/src/components/output/ControlflowPanel.vue
+++ b/src/components/output/ControlflowPanel.vue
@@ -51,7 +51,7 @@ const raw = ref(false);
 </script>
 
 <template>
-  <div class="w-full flex flex-col">
+  <div class="w-full flex flex-col h-full">
     <div class="flex gap-4 p-2">
       <Checkbox v-model="raw" label="Raw" />
       <Checkbox v-model="options.controlFlow.verbose" label="Verbose" />


### PR DESCRIPTION
Adjust the wrapper box height, allow users to scroll and view the whole graph.

<img width="500" height="772" alt="Screenshot 2026-02-04 at 07 28 14" src="https://github.com/user-attachments/assets/63c9aed1-4943-491d-aa76-2675a7b84459" />

<details>

<summary> Before </summary>

<img width="510" height="764" alt="Screenshot 2026-02-04 at 07 29 52" src="https://github.com/user-attachments/assets/c7071b88-86bc-4094-9320-17faff603599" />

</details>

