### PR TITLE
fix: resolve oxc sibling directory in git worktrees

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -9,7 +9,7 @@ import {
   ModuleResolutionKind,
   JsxEmit,
 } from "monaco-editor/esm/vs/language/typescript/monaco.contribution";
-import oxfmtSchema from "../../oxc/npm/oxfmt/configuration_schema.json?url";
+import oxfmtSchema from "@oxc/npm/oxfmt/configuration_schema.json?url";
 
 jsonDefaults.setDiagnosticsOptions({
   allowComments: true,


### PR DESCRIPTION
The playground assumes the oxc repo is a direct sibling (../oxc), which breaks when running from a git worktree. Add a resolveOxcDir() helper that falls back to `git worktree list` to locate the main repo and resolve ../oxc relative to it.

Built with Claude Code. Fixes the app when poor ol' Claude tries messing with it.