### PR TITLE
Add linter rules auto-update workflow

### DIFF
--- a/.github/workflows/update-linter-rules.yml
+++ b/.github/workflows/update-linter-rules.yml
@@ -1,0 +1,34 @@
+name: Update Linter Rules
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 */2 * *" # Every other day at 18:00 UTC.
+
+permissions: {}
+
+jobs:
+  update-linter-rules:
+    name: Update linter rules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run generate:linter-rules
+
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          commit-message: Regenerate linter rules
+          title: Regenerate linter rules
+          body: |
+            Automated update of `src/generated/linter-rules.json` from the
+            [website repo](https://github.com/oxc-project/website/blob/main/.vitepress/data/rules.json).
+          branch: update-linter-rules
+          delete-branch: true


### PR DESCRIPTION
Add a new CI workflow to auto-update the rules used by the Playground by running the generator script. This runs every other day at 18:00 UTC, and opens an automated PR in the Playground repo with the changes if there are any.

Generated with Claude Code