### PR TITLE
gitignore the claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vite/
 tsconfig.tsbuildinfo
 .eslintcache
+.claude/


### PR DESCRIPTION
This lets us easily set up a launch.json for the development server to launch from within Claude Desktop. Without committing it to the repo.