### PR TITLE
fix: Prevent editor hover tooltips from being clipped by adjacent panel

### DIFF
--- a/src/components/MonacoEditor.vue
+++ b/src/components/MonacoEditor.vue
@@ -78,6 +78,7 @@ function initMonaco() {
     minimap: { enabled: false },
     fontSize: 14,
     scrollBeyondLastLine: true,
+    fixedOverflowWidgets: true,
     fontFamily: `ui-monospace, Menlo, Monaco, "Cascadia Code", "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro","Fira Mono", "Droid Sans Mono", "Courier New", monospace`,
     ...props.options,
     theme: props.theme || (isDark.value ? "vs-dark" : "vs"),


### PR DESCRIPTION
Enables `fixedOverflowWidgets` so the hover diagnostics are `position: fixed`. This allows them to escape the splitter panel's `overflow: hidden` boundary.

Before:

<img width="491" height="227" alt="Screenshot 2026-02-22 at 5 03 10 PM" src="https://github.com/user-attachments/assets/9aeb636c-c9b8-4de6-b8c3-f08d019f6726" />

After:

<img width="531" height="179" alt="Screenshot 2026-02-22 at 5 04 36 PM" src="https://github.com/user-attachments/assets/9d2d3e0a-e961-43c0-9a1f-c37dcf7c1071" />

Generated with Claude Code.