### PR TITLE
refactor: use reactive + toRef for formatterPanels and persist options in URL

### DIFF
--- a/src/components/output/FormatterPanel.vue
+++ b/src/components/output/FormatterPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
-import { computed, ref, watchEffect } from "vue";
+import { computed, ref, toRef, watchEffect } from "vue";
 import MonacoEditor from "~/components/MonacoEditor.vue";
 import { defaultFormatterConfig, useOxc } from "~/composables/oxc";
 import { usePrettier } from "~/composables/prettier";
@@ -15,22 +15,10 @@ const { oxc, options } = await useOxc();
 const { prettierOutput, prettierDocOutput, prettierError, prettierVersion, format: formatPrettier } = await usePrettier();
 
 // Use shared state for URL persistence
-const showOutput = computed({
-  get: () => formatterPanels.value.output,
-  set: (v) => (formatterPanels.value.output = v),
-});
-const showIR = computed({
-  get: () => formatterPanels.value.ir,
-  set: (v) => (formatterPanels.value.ir = v),
-});
-const showPrettier = computed({
-  get: () => formatterPanels.value.prettier,
-  set: (v) => (formatterPanels.value.prettier = v),
-});
-const showPrettierDoc = computed({
-  get: () => formatterPanels.value.prettierDoc,
-  set: (v) => (formatterPanels.value.prettierDoc = v),
-});
+const showOutput = toRef(formatterPanels, "output");
+const showIR = toRef(formatterPanels, "ir");
+const showPrettier = toRef(formatterPanels, "prettier");
+const showPrettierDoc = toRef(formatterPanels, "prettierDoc");
 const configError = ref<string>("");
 // whether the details element is open
 const detailsOpen = ref(true);

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -10,6 +10,7 @@ import type { Oxc, OxcOptions } from "oxc-playground";
 const urlParams = useUrlSearchParams<{
   t?: string;
   formatterPanels?: string;
+  options?: string;
   code?: string;
   lintRules?: string;
 }>("history", { removeFalsyValues: true });
@@ -20,12 +21,12 @@ if (urlParams.t) {
 }
 if (urlParams.formatterPanels) {
   const enabledPanels = urlParams.formatterPanels.split(",");
-  formatterPanels.value = {
+  Object.assign(formatterPanels, {
     output: enabledPanels.includes("output"),
     ir: enabledPanels.includes("ir"),
     prettier: enabledPanels.includes("prettier"),
     prettierDoc: enabledPanels.includes("prettierDoc"),
-  };
+  });
 }
 if (urlParams.lintRules) {
   enabledLintRules.value = urlParams.lintRules.split(",").filter(Boolean);
@@ -58,55 +59,61 @@ export const defaultFormatterConfig = {
   experimentalSortImports: undefined,
 };
 
+export const defaultOptions: Required<OxcOptions> = {
+  run: {
+    lint: true,
+    formatter: false,
+    transform: false,
+    isolatedDeclarations: false,
+    whitespace: false,
+    mangle: false,
+    compress: false,
+    scope: true,
+    symbol: true,
+    cfg: true,
+  },
+  parser: {
+    extension: "tsx",
+    allowReturnOutsideFunction: true,
+    preserveParens: true,
+    allowV8Intrinsics: true,
+    semanticErrors: true,
+  },
+  linter: {},
+  formatter: { ...defaultFormatterConfig },
+  transformer: {
+    target: "es2015",
+    useDefineForClassFields: true,
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+  },
+  isolatedDeclarations: {
+    stripInternal: false,
+  },
+  codegen: {
+    normal: true,
+    jsdoc: true,
+    annotation: true,
+    legal: true,
+  },
+  compress: {},
+  mangle: {
+    topLevel: true,
+    keepNames: false,
+  },
+  controlFlow: {
+    verbose: false,
+  },
+  inject: { inject: {} },
+  define: { define: {} },
+};
+
+const defaultOptionsSerialized = JSON.stringify(defaultOptions);
+
 export const useOxc = createGlobalState(async () => {
-  const options = ref<Required<OxcOptions>>({
-    run: {
-      lint: true,
-      formatter: false,
-      transform: false,
-      isolatedDeclarations: false,
-      whitespace: false,
-      mangle: false,
-      compress: false,
-      scope: true,
-      symbol: true,
-      cfg: true,
-    },
-    parser: {
-      extension: "tsx",
-      allowReturnOutsideFunction: true,
-      preserveParens: true,
-      allowV8Intrinsics: true,
-      semanticErrors: true,
-    },
-    linter: {},
-    formatter: { ...defaultFormatterConfig },
-    transformer: {
-      target: "es2015",
-      useDefineForClassFields: true,
-      experimentalDecorators: true,
-      emitDecoratorMetadata: true,
-    },
-    isolatedDeclarations: {
-      stripInternal: false,
-    },
-    codegen: {
-      normal: true,
-      jsdoc: true,
-      annotation: true,
-      legal: true,
-    },
-    compress: {},
-    mangle: {
-      topLevel: true,
-      keepNames: false,
-    },
-    controlFlow: {
-      verbose: false,
-    },
-    inject: { inject: {} },
-    define: { define: {} },
-  });
+  const options = ref<Required<OxcOptions>>(
+    urlParams.options ? JSON.parse(urlParams.options) : structuredClone(defaultOptions),
+  );
   const oxc = await oxcPromise;
   const state = shallowRef(oxc);
   const error = ref<unknown>();
@@ -172,7 +179,7 @@ export const useOxc = createGlobalState(async () => {
   // Sync tab and formatter panels to URL (reactive, no debounce needed)
   watchEffect(() => {
     urlParams.t = activeTab.value !== "codegen" ? activeTab.value : undefined;
-    const enabledPanels = Object.entries(formatterPanels.value)
+    const enabledPanels = Object.entries(formatterPanels)
       .filter(([, enabled]) => enabled)
       .map(([name]) => name);
     urlParams.formatterPanels =
@@ -186,6 +193,16 @@ export const useOxc = createGlobalState(async () => {
     urlParams.lintRules =
       enabledLintRules.value.length > 0 ? enabledLintRules.value.join(",") : undefined;
   });
+
+  // Sync options to URL (debounced since options can change frequently)
+  watchDebounced(
+    options,
+    (opts) => {
+      const serialized = JSON.stringify(toRaw(opts));
+      urlParams.options = serialized === defaultOptionsSerialized ? undefined : serialized;
+    },
+    { debounce: 1000, deep: true },
+  );
 
   // Sync code to URL (debounced to avoid excessive updates while typing)
   watchDebounced(

--- a/src/composables/state.ts
+++ b/src/composables/state.ts
@@ -1,5 +1,5 @@
 import { useDark } from "@vueuse/core";
-import { ref } from "vue";
+import { reactive, ref } from "vue";
 import type { Range } from "~/utils/range";
 
 export const dark = useDark();
@@ -13,7 +13,7 @@ export const outputHoverRange = ref<Range>();
 export const activeTab = ref("codegen");
 
 // Formatter panel checkbox states
-export const formatterPanels = ref({
+export const formatterPanels = reactive({
   output: true,
   ir: false,
   prettier: false,


### PR DESCRIPTION
## Summary
- **`formatterPanels` → `reactive`**: Replaces `ref` with `reactive` in `state.ts`, allowing `FormatterPanel.vue` to use `toRef(formatterPanels, "key")` instead of 4 verbose `computed({ get, set })` wrappers
- **Persist `OxcOptions` in URL**: Extracts `defaultOptions` as a module-level constant and serializes the full options object into a `?options=` query param, so shared playground links preserve the complete configuration
- **Clean URL when defaults**: Compares against a precomputed `defaultOptionsSerialized` string to omit the param entirely when all options match defaults

## Test plan
- [ ] `pnpm lint` passes (type-check + oxlint)
- [ ] Toggle formatter panel checkboxes — URL updates with `formatterPanels=` param
- [ ] Change options (e.g. parser extension, formatter config) — URL updates with `options=` param after 1s debounce
- [ ] Copy a URL with `?options=...` and open in new tab — options are restored
- [ ] Default options produce a clean URL with no `options=` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)