### PR TITLE
fix: ensure run() fires on initial load with URL-persisted options

### DIFF
--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -174,7 +174,7 @@ export const useOxc = createGlobalState(async () => {
     console.error = originalError;
     triggerRef(state);
   }
-  watch([options, editorValue, activeTab, enabledLintRules], run, { deep: true });
+  watch([options, editorValue, activeTab, enabledLintRules], run, { deep: true, immediate: true });
 
   // Sync tab and formatter panels to URL (reactive, no debounce needed)
   watchEffect(() => {


### PR DESCRIPTION
## Summary
- Adds `immediate: true` to the `run()` watcher so it fires once on setup
- Fixes empty formatter output when opening a shared playground link that has `?options=` in the URL
- Root cause: `OutputPanel.updateRunOptions()` derives `run.formatter`/`run.cfg` from `activeTab`. When options are restored from URL, these values already match, so the mutation is a no-op and the deep watcher never fires

## Test plan
- [x] Open a shared link with `?t=formatter&options=...` — formatter output should be populated
- [x] Normal usage unaffected — switching tabs still triggers `run()` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)