### PR TITLE
Regenerate linter rules

### DIFF
--- a/src/generated/linter-rules.json
+++ b/src/generated/linter-rules.json
@@ -211,6 +211,16 @@
   },
   {
     "scope": "eslint",
+    "value": "id-match",
+    "category": "style",
+    "version": "next",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/id-match.html"
+  },
+  {
+    "scope": "eslint",
     "value": "init-declarations",
     "category": "style",
     "version": "0.15.11",
@@ -485,7 +495,7 @@
     "category": "correctness",
     "version": "0.0.3",
     "type_aware": false,
-    "fix": "fixable_fix",
+    "fix": "fixable_suggestion",
     "default": true,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
   },
@@ -728,6 +738,26 @@
     "fix": "fixable_fix",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-implicit-coercion.html"
+  },
+  {
+    "scope": "eslint",
+    "value": "no-implicit-globals",
+    "category": "restriction",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-implicit-globals.html"
+  },
+  {
+    "scope": "eslint",
+    "value": "no-implied-eval",
+    "category": "suspicious",
+    "version": "next",
+    "type_aware": false,
+    "fix": "none",
+    "default": true,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-implied-eval.html"
   },
   {
     "scope": "eslint",
@@ -1541,6 +1571,16 @@
   },
   {
     "scope": "eslint",
+    "value": "prefer-arrow-callback",
+    "category": "style",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "fixable_fix",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/prefer-arrow-callback.html"
+  },
+  {
+    "scope": "eslint",
     "value": "prefer-const",
     "category": "style",
     "version": "1.43.0",
@@ -1608,6 +1648,16 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/prefer-promise-reject-errors.html"
+  },
+  {
+    "scope": "eslint",
+    "value": "prefer-regex-literals",
+    "category": "style",
+    "version": "1.64.0",
+    "type_aware": false,
+    "fix": "pending",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/prefer-regex-literals.html"
   },
   {
     "scope": "eslint",
@@ -1878,6 +1928,16 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/import/namespace.html"
+  },
+  {
+    "scope": "import",
+    "value": "newline-after-import",
+    "category": "style",
+    "version": "next",
+    "type_aware": false,
+    "fix": "fixable_fix",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/import/newline-after-import.html"
   },
   {
     "scope": "import",
@@ -2871,6 +2931,26 @@
   },
   {
     "scope": "jsdoc",
+    "value": "require-throws-description",
+    "category": "style",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-throws-description.html"
+  },
+  {
+    "scope": "jsdoc",
+    "value": "require-throws-type",
+    "category": "pedantic",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-throws-type.html"
+  },
+  {
+    "scope": "jsdoc",
     "value": "require-yields",
     "category": "correctness",
     "version": "0.3.2",
@@ -2878,6 +2958,16 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-yields.html"
+  },
+  {
+    "scope": "jsdoc",
+    "value": "require-yields-type",
+    "category": "pedantic",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-yields-type.html"
   },
   {
     "scope": "jsx_a11y",
@@ -2988,6 +3078,16 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/click-events-have-key-events.html"
+  },
+  {
+    "scope": "jsx_a11y",
+    "value": "control-has-associated-label",
+    "category": "correctness",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/control-has-associated-label.html"
   },
   {
     "scope": "jsx_a11y",
@@ -3118,6 +3218,36 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-distracting-elements.html"
+  },
+  {
+    "scope": "jsx_a11y",
+    "value": "no-interactive-element-to-noninteractive-role",
+    "category": "correctness",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-interactive-element-to-noninteractive-role.html"
+  },
+  {
+    "scope": "jsx_a11y",
+    "value": "no-noninteractive-element-interactions",
+    "category": "correctness",
+    "version": "1.65.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-noninteractive-element-interactions.html"
+  },
+  {
+    "scope": "jsx_a11y",
+    "value": "no-noninteractive-element-to-interactive-role",
+    "category": "correctness",
+    "version": "1.64.0",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-noninteractive-element-to-interactive-role.html"
   },
   {
     "scope": "jsx_a11y",
@@ -4281,6 +4411,16 @@
   },
   {
     "scope": "react",
+    "value": "no-object-type-as-default-prop",
+    "category": "perf",
+    "version": "next",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-object-type-as-default-prop.html"
+  },
+  {
+    "scope": "react",
     "value": "no-react-children",
     "category": "restriction",
     "version": "1.53.0",
@@ -4368,6 +4508,16 @@
     "fix": "none",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-unsafe.html"
+  },
+  {
+    "scope": "react",
+    "value": "no-unstable-nested-components",
+    "category": "suspicious",
+    "version": "next",
+    "type_aware": false,
+    "fix": "none",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-unstable-nested-components.html"
   },
   {
     "scope": "react",
@@ -5265,7 +5415,7 @@
     "category": "restriction",
     "version": "1.12.0",
     "type_aware": true,
-    "fix": "fixable_fix",
+    "fix": "fixable_suggestion",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/non-nullable-type-assertion-style.html"
   },
@@ -7198,6 +7348,16 @@
     "fix": "fixable_fix",
     "default": false,
     "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-unneeded-async-expect-function.html"
+  },
+  {
+    "scope": "vitest",
+    "value": "padding-around-after-all-blocks",
+    "category": "style",
+    "version": "next",
+    "type_aware": false,
+    "fix": "fixable_fix",
+    "default": false,
+    "docs_url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/padding-around-after-all-blocks.html"
   },
   {
     "scope": "vitest",


### PR DESCRIPTION
Automated update of `src/generated/linter-rules.json` from the
[website repo](https://github.com/oxc-project/website/blob/main/.vitepress/data/rules.json).