### PR TITLE
chore(deps): exempt VoidZero deps from minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,22 @@
 verifyDepsBeforeRun: install
+minimumReleaseAgeExclude:
+  - "@oxc-parser/*"
+  - "@oxc-project/*"
+  - "@oxfmt/*"
+  - "@oxlint-tsgolint/*"
+  - "@oxlint/*"
+  - "@rolldown/*"
+  - "@tsdown/*"
+  - "@vitejs/devtools"
+  - "@vitest/*"
+  - "@voidzero-dev/*"
+  - oxc-parser
+  - oxfmt
+  - oxlint
+  - oxlint-tsgolint
+  - rolldown
+  - tsdown
+  - vite
+  - vite-plus
+  - vitest
 packages:


### PR DESCRIPTION
## What changed

Adds the same `minimumReleaseAgeExclude` entries used in oxc-project/oxc#22899 to this repository's `pnpm-workspace.yaml`.

## Why

The Renovate `vite-plus` update in oxc-project/playground#363 pulls newly published VoidZero/Vite toolchain packages. Exempting those package names from pnpm's minimum-release-age policy keeps install verification from blocking those trusted toolchain updates while preserving the policy for other dependencies.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`