### PR TITLE
fix: configure Void cross-origin headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,7 @@ jobs:
 
       - name: Deploy to Void
         if: env.VOID_TOKEN && github.ref_name == 'main'
-        run: |
-          cp _headers dist/_headers
-          pnpm exec void deploy --skip-build
+        run: pnpm exec void deploy --skip-build
         env:
           VOID_PROJECT: oxc-playground
 

--- a/void.json
+++ b/void.json
@@ -6,5 +6,13 @@
     "appType": "static",
     "outputDir": "dist"
   },
-  "routing": {}
+  "routing": {
+    "headers": {
+      "/*": [
+        "X-Frame-Options: DENY",
+        "Cross-Origin-Opener-Policy: same-origin",
+        "Cross-Origin-Embedder-Policy: require-corp"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Void does not consume Netlify's `_headers` file. Configure the COOP/COEP/XFO headers through `void.json` routing instead, and remove the ineffective `_headers` copy from the Void deploy step.\n\nVerification:\n- `pnpm fmt --check`\n- `pnpm lint`\n- `pnpm build`