### PR TITLE
fix(ci):  use GitHub App token for linter rules PR creation

### DIFF
--- a/.github/workflows/update-linter-rules.yml
+++ b/.github/workflows/update-linter-rules.yml
@@ -25,12 +25,24 @@ jobs:
 
       - run: pnpm run generate:linter-rules
 
-      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
         with:
-          commit-message: Regenerate linter rules
-          title: Regenerate linter rules
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        id: pr
+        with:
+          # bot account with PAT required for triggering workflow runs
+          # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore: regenerate linter rules"
+          title: "chore: regenerate linter rules"
+          branch: update-linter-rules
+          branch-suffix: timestamp
+          base: main
           body: |
             Automated update of `src/generated/linter-rules.json` from the
             [website repo](https://github.com/oxc-project/website/blob/main/.vitepress/data/rules.json).
-          branch: update-linter-rules
           delete-branch: true

--- a/.github/workflows/update-linter-rules.yml
+++ b/.github/workflows/update-linter-rules.yml
@@ -40,7 +40,6 @@ jobs:
           commit-message: "chore: regenerate linter rules"
           title: "chore: regenerate linter rules"
           branch: update-linter-rules
-          branch-suffix: timestamp
           base: main
           body: |
             Automated update of `src/generated/linter-rules.json` from the


### PR DESCRIPTION
- create a GitHub App token before opening the automated linter-rules PR
- pass that token into `peter-evans/create-pull-request` so follow-up workflows can run
- match the release workflow's timestamped PR branch/base pattern