### PR TITLE
chore: normalize funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [Boshen, sxzz]
+open_collective: oxc


### PR DESCRIPTION
Remove personal sponsorship targets from selected funding files and direct sponsorship to the Oxc Open Collective only.