### PR TITLE
fix(formatter): use prettier babel parser for JS, typescript for TS

### DIFF
--- a/src/components/output/FormatterPanel.vue
+++ b/src/components/output/FormatterPanel.vue
@@ -35,11 +35,17 @@ const hasDiff = computed(() => {
   return oxc.value.formatterFormattedText !== prettierOutput.value;
 });
 
+// JSDoc type casts are only handled by the babel parser, so match it to the input language
+const prettierParser = computed(() =>
+  ["ts", "mts", "cts", "tsx"].includes(options.value.parser.extension) ? "typescript" : "babel",
+);
+
 // Run Prettier when code, options, or checkboxes change
 watchEffect(async () => {
   if (!showPrettier.value && !showPrettierDoc.value) return;
   const opts = options.value.formatter;
   await formatPrettier(editorValue.value, {
+    parser: prettierParser.value,
     tabWidth: opts.tabWidth,
     useTabs: opts.useTabs,
     printWidth: opts.printWidth,
@@ -73,7 +79,12 @@ const visiblePanels = computed<Panel[]>(() => {
     });
   }
   if (showPrettier.value) {
-    panels.push({ key: "prettier", label: "Prettier", code: prettierOutput.value, lang: "tsx" });
+    panels.push({
+      key: "prettier",
+      label: `Prettier (${prettierParser.value})`,
+      code: prettierOutput.value,
+      lang: "tsx",
+    });
   }
   if (showIR.value) {
     panels.push({ key: "ir", label: "IR", code: oxc.value.formatterIrText, lang: "typescript" });

--- a/src/composables/prettier.ts
+++ b/src/composables/prettier.ts
@@ -14,10 +14,11 @@ const prettier = prettierStandalone as typeof prettierStandalone & {
 let plugins: Plugin[];
 
 const prettierReady = Promise.all([
+  import("prettier/plugins/babel"),
   import("prettier/plugins/typescript"),
   import("prettier/plugins/estree"),
-]).then(([ts, estree]) => {
-  plugins = [ts.default, estree.default];
+]).then(([babel, ts, estree]) => {
+  plugins = [babel.default, ts.default, estree.default];
 });
 
 // Format doc IR as readable string
@@ -61,11 +62,11 @@ export const usePrettier = createGlobalState(async () => {
   const prettierDocOutput = ref("");
   const prettierError = ref("");
 
-  async function format(code: string, options: Options) {
+  async function format(code: string, options: Options & { parser: "babel" | "typescript" }) {
     try {
       prettierError.value = "";
 
-      const formatOptions = { ...options, parser: "typescript" as const, plugins };
+      const formatOptions = { ...options, plugins };
 
       prettierOutput.value = await prettier.format(code, formatOptions);
 


### PR DESCRIPTION
Currently, prettier parser is always specified as `typescript`, even for JS(X).

Prettier's default JS parser is `babel` and `typescript` produces different output. (e.g. preserve JSDoc parens)
