### PR TITLE
ci: migrate Void deploy to OIDC and bump void to ^0.10.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'void' || '' }}
     env:
       SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
     permissions:
+      id-token: write
       pull-requests: write
       contents: write
     steps:
@@ -110,7 +110,7 @@ jobs:
           cat deploy_output.json
 
       - name: Deploy to Void
-        if: env.VOID_TOKEN && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         run: pnpm exec void deploy --skip-build
         env:
           VOID_PROJECT: oxc-playground

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^6.0.0",
     "vite-plus": "0.2.5",
-    "void": "^0.10.0",
+    "void": "^0.10.10",
     "vue-tsc": "~3.3.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: 0.2.5
         version: 0.2.5(@types/node@25.0.10)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.23.0)(typescript@6.0.3)(vite@8.0.0-beta.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.0.10)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.23.0))
       void:
-        specifier: ^0.10.0
+        specifier: ^0.10.10
         version: 0.10.10(arktype@2.2.0)(kysely@0.29.3)(valibot@1.4.1(typescript@6.0.3))(vite@8.0.0-beta.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.0.10)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.23.0))(vitest@4.1.10)(vue@3.5.39(typescript@6.0.3))(workerd@1.20260708.1)(zod@4.4.3)
       vue-tsc:
         specifier: ~3.3.0


### PR DESCRIPTION
Authenticate the Void deploy in CI via **GitHub OIDC** instead of a stored `VOID_TOKEN` secret. `void deploy` detects it is running in GitHub Actions, mints a `void`-audience OIDC token, and exchanges it at `POST /auth/github-oidc` for a short-lived, project-scoped deploy token — so no long-lived secret is stored.

## Changes

- Grant `id-token: write` on the `build` job (lets the job mint the OIDC token).
- Drop `VOID_TOKEN` from the job `env` and gate the deploy on `main` only.
- Bump `void` `^0.10.0` → `^0.10.10` (latest).

## Required follow-up (server-side, one-time)

OIDC exchange only succeeds once the repo is connected to the `oxc-playground` project with the `github_actions` executor on Void. Run once locally with a Void login + the Void GitHub App installed:

```bash
void github connect oxc-playground \
  --repo oxc-project/playground \
  --branch main \
  --executor github_actions \
  --workflow .github/workflows/ci.yml
```

After the first successful OIDC deploy, the now-unused `VOID_TOKEN` secret can be removed from the `void` GitHub environment.