### PR TITLE
ci: deploy scheduled refreshes via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
 on:
+  # Scheduled refreshes arrive as `workflow_dispatch` from scheduled-deploy.yml,
+  # because Void's OIDC deploy rejects the `schedule` event as a trigger.
   workflow_dispatch:
-  schedule:
-    - cron: "0 */3 * * *" # Build and deploy every 3 hours.
   pull_request:
     types:
       - opened
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   check:
     name: Check
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
@@ -37,7 +37,7 @@ jobs:
 
   check-linter-rules:
     name: Check linter rules up-to-date
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -1,0 +1,23 @@
+name: Scheduled deploy
+
+# Rebuild and redeploy the playground against oxc `main` every 3 hours.
+# The cron cannot deploy directly: Void's OIDC executor rejects the `schedule`
+# event as a deploy trigger. So this workflow only dispatches CI, and the real
+# build+deploy runs there under `workflow_dispatch`, which OIDC accepts.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Dispatch CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - run: gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" --ref main
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The every-3-hours scheduled deploy fails at the **Deploy to Void** step:

```
github-oidc: OIDC token exchange failed (401):
{"error":"oidc token event is not an allowed deploy trigger"}
```

Since #404 migrated the Void deploy to OIDC, `void deploy` mints a GitHub OIDC token and exchanges it server-side. Void reads the `event_name` claim and only accepts certain triggers — `schedule` is not one of them. `push`-to-main deploys via OIDC succeed; only the cron refresh fails.

## Fix

Move the cron out of `ci.yml` into a new `scheduled-deploy.yml` that dispatches CI:

- `scheduled-deploy.yml` runs on the `0 */3 * * *` cron and calls `gh workflow run ci.yml --ref main` (default `GITHUB_TOKEN`, `actions: write`).
- The build+deploy then runs under `workflow_dispatch`, which OIDC accepts. `workflow_dispatch` is the documented exception to GitHub's no-recursion rule, so no PAT is needed.
- Both check jobs switch their gate from `!= 'schedule'` to `!= 'workflow_dispatch'`, so the refresh keeps skipping `fmt`/typos/linter-rules exactly as before.

## Note

`push` is confirmed Void-allowed; `workflow_dispatch` is inferred. After merge, trigger one manual run (`gh workflow run ci.yml --ref main`) and confirm the Deploy to Void step is green. If Void also blocks `workflow_dispatch`, the fallback is to pass `VOID_TOKEN` only on the refresh path, which bypasses the OIDC trigger check.
