### PR TITLE
ci: retry scheduled workflow dispatch

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -18,6 +18,16 @@ jobs:
     permissions:
       actions: write
     steps:
-      - run: gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" --ref main
+      - name: Dispatch CI
+        run: |
+          for attempt in 1 2 3; do
+            if gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" --ref main; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Retry scheduled CI dispatches to tolerate transient GitHub API failures.