### PR TITLE
feat: add property mangling controls

### DIFF
--- a/src/components/sidebar/MangleProperties.vue
+++ b/src/components/sidebar/MangleProperties.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import Checkbox from "~/components/ui/Checkbox.vue";
 import { useOxc } from "~/composables/oxc";
 import { Button } from "~/ui/button";
@@ -19,19 +19,54 @@ import { Switch } from "~/ui/switch";
 
 const { options } = await useOxc();
 
+// Keep editing text separate so normalization does not remove spaces or newlines
+// while the user is still typing.
+const excludeInput = ref(options.value.mangleProps.exclude ?? "");
+const reservedInput = ref((options.value.mangleProps.reserved ?? []).join("\n"));
+
+function normalizeExclude(value: string) {
+  return value.trim() ? value : undefined;
+}
+
+function normalizeReserved(value: string) {
+  return value
+    .split(/\r?\n/)
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
 const excludedProperties = computed({
-  get: () => options.value.mangleProps.exclude ?? "",
+  get: () => excludeInput.value,
   set: (value: string | number) => {
-    options.value.mangleProps.exclude = String(value) || undefined;
+    excludeInput.value = String(value);
+    options.value.mangleProps.exclude = normalizeExclude(excludeInput.value);
   },
 });
 
 const reservedProperties = computed({
-  get: () => (options.value.mangleProps.reserved ?? []).join("\n"),
+  get: () => reservedInput.value,
   set: (value: string) => {
-    options.value.mangleProps.reserved = value ? value.split("\n") : [];
+    reservedInput.value = value;
+    options.value.mangleProps.reserved = normalizeReserved(value);
   },
 });
+
+// Reflect edits from the JSON options dialog without overwriting current drafts.
+watch(
+  () => options.value.mangleProps,
+  (properties) => {
+    if (normalizeExclude(excludeInput.value) !== properties.exclude) {
+      excludeInput.value = properties.exclude ?? "";
+    }
+    if (
+      JSON.stringify(normalizeReserved(reservedInput.value)) !==
+      JSON.stringify(properties.reserved ?? [])
+    ) {
+      reservedInput.value = (properties.reserved ?? []).join("\n");
+    }
+  },
+  { deep: true, flush: "sync" },
+);
 </script>
 
 <template>

--- a/src/components/sidebar/MangleProperties.vue
+++ b/src/components/sidebar/MangleProperties.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { Icon } from "@iconify/vue";
+import { computed } from "vue";
+import Checkbox from "~/components/ui/Checkbox.vue";
+import { useOxc } from "~/composables/oxc";
+import { Button } from "~/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/ui/dialog";
+import { Input } from "~/ui/input";
+import { Switch } from "~/ui/switch";
+
+const { options } = await useOxc();
+
+const excludedProperties = computed({
+  get: () => options.value.mangleProps.exclude ?? "",
+  set: (value: string | number) => {
+    options.value.mangleProps.exclude = String(value) || undefined;
+  },
+});
+
+const reservedProperties = computed({
+  get: () => (options.value.mangleProps.reserved ?? []).join("\n"),
+  set: (value: string) => {
+    options.value.mangleProps.reserved = value ? value.split("\n") : [];
+  },
+});
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <label class="flex items-center gap-2">
+      <Switch v-model:checked="options.run.mangleProps" />
+      <h3 class="text-base font-medium">Mangle Properties</h3>
+    </label>
+
+    <Dialog>
+      <DialogTrigger as-child>
+        <Button variant="outline" size="sm" class="self-start">
+          <Icon icon="ri:settings-line" aria-hidden="true" />
+          Configure properties
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent class="max-h-[85vh] w-[calc(100%-2rem)] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Property mangling</DialogTitle>
+          <DialogDescription>
+            Choose which property names to rename. Changes apply immediately.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div class="flex flex-col gap-5">
+          <label class="flex flex-col gap-2 text-sm">
+            <span class="font-medium">Include pattern</span>
+            <Input v-model="options.mangleProps.include" class="font-mono" />
+            <span class="text-xs text-muted-foreground">
+              Rust regex. The default _$ matches names ending in an underscore.
+            </span>
+          </label>
+
+          <label class="flex flex-col gap-2 text-sm">
+            <span class="font-medium">Exclude pattern</span>
+            <Input
+              v-model="excludedProperties"
+              class="font-mono"
+              placeholder="Optional regex pattern"
+            />
+          </label>
+
+          <label class="flex flex-col gap-2 text-sm">
+            <span class="font-medium">Reserved names</span>
+            <textarea
+              v-model="reservedProperties"
+              rows="3"
+              class="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              placeholder="One property name per line"
+            />
+          </label>
+
+          <div class="flex flex-col gap-2">
+            <Checkbox v-model="options.mangleProps.quoted" label="Mangle quoted properties" />
+            <p class="text-xs text-muted-foreground">
+              Also rename quoted properties. Otherwise, quoted names are preserved.
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <Checkbox v-model="options.mangleProps.debug" label="Readable debug names" />
+            <p class="text-xs text-muted-foreground">Use names such as _$name$_.</p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose as-child>
+            <Button>Done</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  </div>
+</template>

--- a/src/components/sidebar/Minifier.vue
+++ b/src/components/sidebar/Minifier.vue
@@ -1,9 +1,25 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import Checkbox from "~/components/ui/Checkbox.vue";
 import { useOxc } from "~/composables/oxc";
+import { Input } from "~/ui/input";
 import { Switch } from "~/ui/switch";
 
 const { options } = await useOxc();
+
+const excludedProperties = computed({
+  get: () => options.value.mangleProps.exclude ?? "",
+  set: (value: string | number) => {
+    options.value.mangleProps.exclude = String(value) || undefined;
+  },
+});
+
+const reservedProperties = computed({
+  get: () => (options.value.mangleProps.reserved ?? []).join("\n"),
+  set: (value: string) => {
+    options.value.mangleProps.reserved = value ? value.split("\n") : [];
+  },
+});
 </script>
 
 <template>
@@ -42,6 +58,57 @@ const { options } = await useOxc();
           label="keepNames"
           label-class="text-xs font-mono"
         />
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-3">
+      <label class="flex items-center gap-2">
+        <Switch v-model:checked="options.run.mangleProps" />
+        <h3 class="text-base font-medium">Mangle Properties</h3>
+      </label>
+
+      <div class="ml-2 flex flex-col gap-2">
+        <label class="flex flex-col gap-1 text-xs">
+          <span class="font-mono">include</span>
+          <Input v-model="options.mangleProps.include" class="h-8 p-1 font-mono" />
+          <span class="text-muted-foreground">
+            Regex pattern. The default _$ matches properties ending in an underscore.
+          </span>
+        </label>
+
+        <label class="flex flex-col gap-1 text-xs">
+          <span class="font-mono">exclude</span>
+          <Input
+            v-model="excludedProperties"
+            class="h-8 p-1 font-mono"
+            placeholder="Optional regex pattern"
+          />
+        </label>
+
+        <label class="flex flex-col gap-1 text-xs">
+          <span class="font-mono">reserved</span>
+          <textarea
+            v-model="reservedProperties"
+            rows="3"
+            class="w-full rounded-md border border-input bg-transparent p-1 font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            placeholder="One property name per line"
+          />
+        </label>
+
+        <Checkbox
+          v-model="options.mangleProps.quoted"
+          label="quoted"
+          label-class="text-xs font-mono"
+        />
+        <p class="text-xs text-muted-foreground">
+          Also mangle quoted properties. Otherwise, quoted names are preserved.
+        </p>
+        <Checkbox
+          v-model="options.mangleProps.debug"
+          label="debug"
+          label-class="text-xs font-mono"
+        />
+        <p class="text-xs text-muted-foreground">Use readable names such as _$name$_.</p>
       </div>
     </div>
   </section>

--- a/src/components/sidebar/Minifier.vue
+++ b/src/components/sidebar/Minifier.vue
@@ -1,25 +1,10 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import MangleProperties from "~/components/sidebar/MangleProperties.vue";
 import Checkbox from "~/components/ui/Checkbox.vue";
 import { useOxc } from "~/composables/oxc";
-import { Input } from "~/ui/input";
 import { Switch } from "~/ui/switch";
 
 const { options } = await useOxc();
-
-const excludedProperties = computed({
-  get: () => options.value.mangleProps.exclude ?? "",
-  set: (value: string | number) => {
-    options.value.mangleProps.exclude = String(value) || undefined;
-  },
-});
-
-const reservedProperties = computed({
-  get: () => (options.value.mangleProps.reserved ?? []).join("\n"),
-  set: (value: string) => {
-    options.value.mangleProps.reserved = value ? value.split("\n") : [];
-  },
-});
 </script>
 
 <template>
@@ -61,55 +46,6 @@ const reservedProperties = computed({
       </div>
     </div>
 
-    <div class="flex flex-col gap-3">
-      <label class="flex items-center gap-2">
-        <Switch v-model:checked="options.run.mangleProps" />
-        <h3 class="text-base font-medium">Mangle Properties</h3>
-      </label>
-
-      <div class="ml-2 flex flex-col gap-2">
-        <label class="flex flex-col gap-1 text-xs">
-          <span class="font-mono">include</span>
-          <Input v-model="options.mangleProps.include" class="h-8 p-1 font-mono" />
-          <span class="text-muted-foreground">
-            Regex pattern. The default _$ matches properties ending in an underscore.
-          </span>
-        </label>
-
-        <label class="flex flex-col gap-1 text-xs">
-          <span class="font-mono">exclude</span>
-          <Input
-            v-model="excludedProperties"
-            class="h-8 p-1 font-mono"
-            placeholder="Optional regex pattern"
-          />
-        </label>
-
-        <label class="flex flex-col gap-1 text-xs">
-          <span class="font-mono">reserved</span>
-          <textarea
-            v-model="reservedProperties"
-            rows="3"
-            class="w-full rounded-md border border-input bg-transparent p-1 font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            placeholder="One property name per line"
-          />
-        </label>
-
-        <Checkbox
-          v-model="options.mangleProps.quoted"
-          label="quoted"
-          label-class="text-xs font-mono"
-        />
-        <p class="text-xs text-muted-foreground">
-          Also mangle quoted properties. Otherwise, quoted names are preserved.
-        </p>
-        <Checkbox
-          v-model="options.mangleProps.debug"
-          label="debug"
-          label-class="text-xs font-mono"
-        />
-        <p class="text-xs text-muted-foreground">Use readable names such as _$name$_.</p>
-      </div>
-    </div>
+    <MangleProperties />
   </section>
 </template>

--- a/src/composables/oxc.ts
+++ b/src/composables/oxc.ts
@@ -67,6 +67,7 @@ export const defaultOptions: Required<OxcOptions> = {
     isolatedDeclarations: false,
     whitespace: false,
     mangle: false,
+    mangleProps: false,
     compress: false,
     scope: true,
     symbol: true,
@@ -102,6 +103,13 @@ export const defaultOptions: Required<OxcOptions> = {
   mangle: {
     topLevel: true,
     keepNames: false,
+  },
+  mangleProps: {
+    include: "_$",
+    exclude: undefined,
+    reserved: [],
+    quoted: false,
+    debug: false,
   },
   controlFlow: {
     verbose: false,


### PR DESCRIPTION
Adds an independent Mangle Properties toggle and a configuration dialog for include/exclude regex patterns, reserved names, quoted-property mangling, and readable debug names. Settings are preserved in shared URLs; the default pattern targets properties ending in an underscore.

Requires https://github.com/oxc-project/oxc/pull/26408 before merging.
