### PR TITLE
fix: restore Monaco hover tooltips

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,5 @@
 import "monaco-editor/editor/editor.api";
+import "monaco-editor/editor/contrib/hover/browser/hoverContribution";
 import "monaco-editor/languages/definitions/javascript/register";
 import "monaco-editor/languages/definitions/typescript/register";
 import { jsonDefaults } from "monaco-editor/language/json/monaco.contribution";


### PR DESCRIPTION
Hover tooltips broke after upgrading Monaco from 0.55.1 to 0.56.0. This import restores them

 current playground:

  https://github.com/user-attachments/assets/04502e15-4f6c-4b84-9c6a-3f9617d795a4

 after the fix (running locally):

  https://github.com/user-attachments/assets/e852f584-3d01-4707-a798-f6160c0bcd41